### PR TITLE
Fix the bug of incorrect sequence input for GRU.

### DIFF
--- a/clone/model.py
+++ b/clone/model.py
@@ -141,7 +141,7 @@ class BatchProgramCC(nn.Module):
         # return encodes
 
         gru_out, _ = self.bigru(encodes, self.hidden)
-        gru_out, _ = nn.utils.rnn.pad_packed_sequence(gru_out, padding_value=-1e9)
+        gru_out, _ = nn.utils.rnn.pad_packed_sequence(gru_out, batch_first=True, padding_value=-1e9)
 
         gru_out = torch.transpose(gru_out, 1, 2)
         # pooling

--- a/clone/model.py
+++ b/clone/model.py
@@ -141,7 +141,7 @@ class BatchProgramCC(nn.Module):
         # return encodes
 
         gru_out, _ = self.bigru(encodes, self.hidden)
-        gru_out, _ = nn.utils.rnn.pack_padded_sequence(gru_out, torch.tensor(lens), enforce_sorted=False)
+        gru_out, _ = nn.utils.rnn.pad_packed_sequence(gru_out, padding_value=-1e9)
 
         gru_out = torch.transpose(gru_out, 1, 2)
         # pooling

--- a/clone/model.py
+++ b/clone/model.py
@@ -140,7 +140,9 @@ class BatchProgramCC(nn.Module):
         encodes = nn.utils.rnn.pack_padded_sequence(encodes, torch.LongTensor(lens), True, False)
         # return encodes
 
-        gru_out, hidden = self.bigru(encodes, self.hidden)
+        gru_out, _ = self.bigru(encodes, self.hidden)
+        gru_out, _ = nn.utils.rnn.pack_padded_sequence(gru_out, torch.tensor(lens), enforce_sorted=False)
+
         gru_out = torch.transpose(gru_out, 1, 2)
         # pooling
         gru_out = F.max_pool1d(gru_out, gru_out.size(2)).squeeze(2)

--- a/clone/model.py
+++ b/clone/model.py
@@ -131,12 +131,13 @@ class BatchProgramCC(nn.Module):
         seq, start, end = [], 0, 0
         for i in range(self.batch_size):
             end += lens[i]
+            seq.append(encodes[start:end])
             if max_len-lens[i]:
                 seq.append(self.get_zeros(max_len-lens[i]))
-            seq.append(encodes[start:end])
             start = end
         encodes = torch.cat(seq)
         encodes = encodes.view(self.batch_size, max_len, -1)
+        encodes = nn.utils.rnn.pack_padded_sequence(encodes, torch.LongTensor(lens), True, False)
         # return encodes
 
         gru_out, hidden = self.bigru(encodes, self.hidden)

--- a/model.py
+++ b/model.py
@@ -143,7 +143,7 @@ class BatchProgramClassifier(nn.Module):
 
         # gru
         gru_out, _ = self.bigru(encodes, self.hidden)
-        gru_out, _ = nn.utils.rnn.pack_padded_sequence(gru_out, torch.tensor(lens), enforce_sorted=False)
+        gru_out, _ = nn.utils.rnn.pad_packed_sequence(gru_out, padding_value=-1e9)
 
         gru_out = torch.transpose(gru_out, 1, 2)
         # pooling

--- a/model.py
+++ b/model.py
@@ -142,7 +142,8 @@ class BatchProgramClassifier(nn.Module):
         encodes = nn.utils.rnn.pack_padded_sequence(encodes, torch.LongTensor(lens), True, False)
 
         # gru
-        gru_out, hidden = self.bigru(encodes, self.hidden)
+        gru_out, _ = self.bigru(encodes, self.hidden)
+        gru_out, _ = nn.utils.rnn.pack_padded_sequence(gru_out, torch.tensor(lens), enforce_sorted=False)
 
         gru_out = torch.transpose(gru_out, 1, 2)
         # pooling

--- a/model.py
+++ b/model.py
@@ -143,7 +143,7 @@ class BatchProgramClassifier(nn.Module):
 
         # gru
         gru_out, _ = self.bigru(encodes, self.hidden)
-        gru_out, _ = nn.utils.rnn.pad_packed_sequence(gru_out, padding_value=-1e9)
+        gru_out, _ = nn.utils.rnn.pad_packed_sequence(gru_out, batch_first=True, padding_value=-1e9)
 
         gru_out = torch.transpose(gru_out, 1, 2)
         # pooling

--- a/model.py
+++ b/model.py
@@ -133,12 +133,13 @@ class BatchProgramClassifier(nn.Module):
         seq, start, end = [], 0, 0
         for i in range(self.batch_size):
             end += lens[i]
+            seq.append(encodes[start:end])
             if max_len-lens[i]:
                 seq.append(self.get_zeros(max_len-lens[i]))
-            seq.append(encodes[start:end])
             start = end
         encodes = torch.cat(seq)
         encodes = encodes.view(self.batch_size, max_len, -1)
+        encodes = nn.utils.rnn.pack_padded_sequence(encodes, torch.LongTensor(lens), True, False)
 
         # gru
         gru_out, hidden = self.bigru(encodes, self.hidden)


### PR DESCRIPTION
Currently, the padding method for GRU input is adding zero tensor before the real input. This introduces an incompatible error with the standard GRU, which does not match the descriptions of GRU in the paper. 

More specifically, there are bias terms in GRU components. Although both initial hidden state h_0 and and useless paddings are set to zero tensors, GRU still provides a non-zero hidden state h_0 for sequences that do not reach maximum sequence length but provides a zero hidden state h_0 for sequences that have maximum sequence length.

For example, for input sequence with paddings such as [[0, 0, 0], [1, 3, 2], [2, 1, 2]], h_0 is a non-zero tensor. But for input sequence without paddings such as [[3, 2, 4], [1, 3, 2], [2, 1, 2]], h_0 is a zero tensor.